### PR TITLE
License-Image

### DIFF
--- a/feeds/demo/feed.cfg
+++ b/feeds/demo/feed.cfg
@@ -50,3 +50,12 @@ firtz
 
 #: flattrid:
 #: eazyliving
+
+licenseurl:
+http://creativecommons.org/licenses/by/4.0/
+
+licensename:
+Creative Commons Namensnennung 4.0 International Lizenz
+
+licenseimg:
+https://i.creativecommons.org/l/by/4.0/88x31.png

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ $main->set('audio','');
 
 $main->set('firtzattr_default',array('feedalias','baseurlredirect'));
 
-$main->set('feedattr_default',array('title','description','formats','flattrid','author','summary','image','keywords','category','email','language','explicit','itunes','disqus','auphonic-path','auphonic-glob','auphonic-url','auphonic-mode','twitter','adn','itunesblock','mediabaseurl','mediabasepath','redirect','bitlove','cloneurl','clonepath','licenseurl','licensename','rfc5005','pagedcount','baseurl','adntoken','feedalias'));
+$main->set('feedattr_default',array('title','description','formats','flattrid','author','summary','image','keywords','category','email','language','explicit','itunes','disqus','auphonic-path','auphonic-glob','auphonic-url','auphonic-mode','twitter','adn','itunesblock','mediabaseurl','mediabasepath','redirect','bitlove','cloneurl','clonepath','licenseurl','licensename','rfc5005','pagedcount','baseurl','adntoken','feedalias','licenseimg'));
 
 $main->set('itemattr',array('title','description','link','guid','article','payment','chapters','enclosure','duration','keywords','image','date','noaudio','adnthread','location'));
 $main->set('extattr',array('slug','template','arguments','prio','script','type')); 

--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ $main->set('audio','');
 
 $main->set('firtzattr_default',array('feedalias','baseurlredirect'));
 
-$main->set('feedattr_default',array('title','description','formats','flattrid','author','summary','image','keywords','category','email','language','explicit','itunes','disqus','auphonic-path','auphonic-glob','auphonic-url','auphonic-mode','twitter','adn','itunesblock','mediabaseurl','mediabasepath','redirect','bitlove','cloneurl','clonepath','licenseurl','licensename','rfc5005','pagedcount','baseurl','adntoken','feedalias','licenseimg'));
+$main->set('feedattr_default',array('title','description','formats','flattrid','author','summary','image','keywords','category','email','language','explicit','itunes','disqus','auphonic-path','auphonic-glob','auphonic-url','auphonic-mode','twitter','adn','itunesblock','mediabaseurl','mediabasepath','redirect','bitlove','cloneurl','clonepath','licenseurl','licensename','licenseimg','rfc5005','pagedcount','baseurl','adntoken','feedalias'));
 
 $main->set('itemattr',array('title','description','link','guid','article','payment','chapters','enclosure','duration','keywords','image','date','noaudio','adnthread','location'));
 $main->set('extattr',array('slug','template','arguments','prio','script','type')); 

--- a/templates/site.html
+++ b/templates/site.html
@@ -209,7 +209,14 @@
 			<span>| email: <a href="mailto:{{@feedattr.email}}">{{@feedattr.email}}</a></span>
 		</check>
 		<check if="{{@feedattr.licensename}}">
-			<span>| {{@dict_license}}: <a href="{{@feedattr.licenseurl}}">{{@feedattr.licensename}}</a></span>
+			<check if="{{@feedattr.licenseimg}}">
+				<true>
+					<span>|&nbsp;{{@dict_license}}:&nbsp;<a href="{{@feedattr.licenseurl}}" title="{{@feedattr.licensename}}"><img src="{{@feedattr.licenseimg}}" alt="{{@feedattr.licensename}}" /></a></span>
+				</true>
+				<false>
+					<span>|&nbsp;{{@dict_license}}:&nbsp;<a href="{{@feedattr.licenseurl}}" title="{{@feedattr.licensename}}">{{@feedattr.licensename}}</a></span>
+				</false>
+			</check>
 		</check>
         <repeat group="{{glob(@templatepath.'/footer/*.html')}}" value="{{@template}}">
 				<include href="{{'footer/'.basename(@template)}}"/>


### PR DESCRIPTION
Hallo,

ich habe für meine Firtz-Installation eine Option zur Anzeige einer Lizenz-Grafik anstatt des Lizenz-Namens eingebaut.
Wird der entsprechende Eintrag in der feed.cfg nicht gesetzt wird weiterhin der Lizenz-Name angezeigt.

Im Einsatz zu sehen ist das hier: http://www.leseraum.eu/leseraum/show