### PR TITLE
Speakers

### DIFF
--- a/classes/episode.php
+++ b/classes/episode.php
@@ -94,6 +94,10 @@
 						$item[$tagname]=$tagval;
 						unset($prod->metadata->tags[$key]);
 					}
+					if ($tagname == 'speakers' ) {
+						$item['speakers'] = explode(" ", $tagval);
+						unset($prod->metadata->tags[$key]);
+					}
 				}
 			
 			}
@@ -210,8 +214,9 @@
 				} else {
 					
 					/* this is an attribute which may have linebreaks. append line to current attribute */
-					if ($thisattr!="" && $thisattr!="article") $item[$thisattr] .= ($item[$thisattr]!="") ? "\n".$line : $line;
+					if ($thisattr!="" && $thisattr!="article" && $thisattr!="speakers") $item[$thisattr] .= ($item[$thisattr]!="") ? "\n".$line : $line;
 					if ($thisattr == "article") $item[$thisattr] .= ($item[$thisattr]!="") ? "\n".$uline : $uline;
+					if ($thisattr == "speakers") $item[$thisattr] = explode (" ", $line);
 				}
 				
 			}

--- a/dict/de.php
+++ b/dict/de.php
@@ -6,6 +6,7 @@ return array(
 	'dict_showcomments'=>'Kommentare zeigen oder schreiben',
 	'dict_show_adn_thread'=>'Thread auf App.net anzeigen',
 	'dict_license'=>'Lizenz',
+	'dict_speakers'=>'Sprecher',
 	'dict_older'=>'&auml;lter',
 	'dict_newer'=>'neuer',
 	'dict_reply'=>'antworten'

--- a/dict/en.php
+++ b/dict/en.php
@@ -6,6 +6,7 @@ return array(
 	'dict_showcomments'=>'show comments',
 	'dict_show_adn_thread'=>'Show thread on App.net',
 	'dict_license'=>'license',
+	'dict_speakers'=>'Speakers',
 	'dict_older'=>'older',
 	'dict_newer'=>'newer',
 	'dict_reply'=>'reply'

--- a/feeds/demo/001.epi
+++ b/feeds/demo/001.epi
@@ -38,3 +38,6 @@ http://podcast.hoersuppe.de/fz001.m4a
 
 opus:
 http://podcast.hoersuppe.de/fz001.opus
+
+speakers:
+john_doe

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ $main->set('firtzattr_default',array('feedalias','baseurlredirect'));
 
 $main->set('feedattr_default',array('title','description','formats','flattrid','author','summary','image','keywords','category','email','language','explicit','itunes','disqus','auphonic-path','auphonic-glob','auphonic-url','auphonic-mode','twitter','adn','itunesblock','mediabaseurl','mediabasepath','redirect','bitlove','cloneurl','clonepath','licenseurl','licensename','rfc5005','pagedcount','baseurl','adntoken','feedalias'));
 
-$main->set('itemattr',array('title','description','link','guid','article','payment','chapters','enclosure','duration','keywords','image','date','noaudio','adnthread','location'));
+$main->set('itemattr',array('title','description','link','guid','article','payment','chapters','enclosure','duration','keywords','image','date','noaudio','adnthread','location','speakers'));
 $main->set('extattr',array('slug','template','arguments','prio','script','type')); 
 
 $main->set('mimetypes',array('mp3'=>'audio/mpeg','torrent'=>'application/x-bittorrent','mpg'=>'video/mpeg','m4a'=>'audio/mp4','m4v'=>'video/mp4','oga'=>'audio/ogg','ogg'=>'audio/ogg','ogv'=>'video/ogg','webm'=>'audio/webm','webm'=>'video/webm','flac'=>'audio/flac','opus'=>'audio/ogg;codecs=opus','mka'=>'audio/x-matroska','mkv'=>'video/x-matroska','pdf'=>'application/pdf','epub'=>'application/epub+zip','png'=>'image/png','jpg'=>'image/jpeg','mobi'=>'application/x-mobipocket-ebook'));

--- a/templates/site.html
+++ b/templates/site.html
@@ -154,6 +154,13 @@
 				</ul>
 			</div>
 			</check>
+			<check if="{{@item.speakers}}">
+				<h5>{{@dict_speakers}}</h5>
+				<repeat group="@item.speakers" value="{{@speaker}}">
+					<include href="{{'speakers/' . @speaker . '.html'}}" />
+				</repeat>
+				<br>
+			</check>
 			<check if="{{@feedattr.flattrid}}">
 				<iframe src="https://api.flattr.com/button/view/?user_id={{@feedattr.flattrid}}&amp;url={{@item.flattrlink | raw}}&amp;language={{@feedattr.flattrlanguage | raw}}&amp;category=audio&amp;title={{@item.flattrtitle | raw}}&amp;description={{@item.flattrdescription | raw}}&amp;tags={{@item.flattrkeywords | raw}}&amp;popout=0&amp;button=compact"
 				class="FlattrButton" width="110" height="20" frameborder="0" scrolling="no" border="0" marginheight="0" marginwidth="0" allowtransparency="true">

--- a/templates/speakers/john_doe.html
+++ b/templates/speakers/john_doe.html
@@ -1,0 +1,3 @@
+			<div style="margin-left: 10px;">
+				John Doe
+			</div>


### PR DESCRIPTION
Ein Feature welches ich im Firtz bisher vermisst habe, war eine Möglichkeit die Sprecher einer einzelnen Folge zu listen und damit zu unterstützen.
Ich habe daher ein paar kleine Änderungen vorgenommen um dieses Feature zu implementieren.
Mittels der Einstellung "speakers" (entweder in der .epi oder über "_speakers:" in den Auphonic-Tags) können die Sprechernamen hinterlegt werden.
Definiert man also z.B. "speakers: john_doe" sucht Firtz im Template-Ordner nach dem Verzeichnis "speakers" und darin nach der Datei john_doe.html
Diese wird dann an entsprechender Stelle in der Webseite eingebaut.

Im Feed wird es aktuell noch nicht übernommen, da ich nicht weiß, ob es dafür sinnvolle Feed-Entities gibt... kann aber leicht auch in die Feeds eingebaut werden, wenn mir jemand sagen kann, wie das in die Feed-Struktur hinein gehört.

Ich habe dieses System bereits live im Einsatz. Zu sehen unter http://www.leseraum.eu/leseraum/show